### PR TITLE
Improve sanitizeError for low relayer fees

### DIFF
--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -72,6 +72,14 @@ export const sanitizeError = (cause: Error): Error => {
         { cause },
       );
     }
+    if (
+      lowercaseMsg.includes('spendable private balance too low') &&
+      lowercaseMsg.includes('relayer fee')
+    ) {
+      return new Error('Private balance too low to pay relayer fee.', {
+        cause,
+      });
+    }
 
     // Custom RAILGUN contract error messages
     if (lowercaseMsg.includes('railgunsmartwallet')) {


### PR DESCRIPTION
Handles a new error case in `sanitizeError`.

PS: `sanitizeError` had already been [fixed to remove duplicate error causes](https://github.com/Railgun-Community/shared-models/pull/10), but we didn't transpile TS to JS when publishing the new version, so the JS was still outdated. Now when we release a new version of shared-models, we should make sure the JS is transpiled.