### PR TITLE
Add support for web socket provider in health check and matching test

### DIFF
--- a/src/utils/__tests__/available-rpc.test.ts
+++ b/src/utils/__tests__/available-rpc.test.ts
@@ -8,8 +8,8 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-describe('available-rpc', () => {
-  it('Should check fallback provider cascade', async () => {
+describe.only('available-rpc', () => {
+  it('Should check fallback provider cascade for FallbackProvider of HTTPS RPCs', async () => {
     const config: FallbackProviderJsonConfig = {
       chainId: 1,
       providers: [
@@ -21,6 +21,24 @@ describe('available-rpc', () => {
         },
         { provider: 'https://cloudflare-eth.com/', priority: 3, weight: 1 },
         { provider: 'https://rpc.ankr.com/eth', priority: 3, weight: 1 },
+      ],
+    };
+
+    const fallbackProvider = createFallbackProviderFromJsonConfig(config);
+
+    await fallbackProvider.getBlockNumber();
+  }).timeout(5000);
+
+  it('Should check fallback provider cascade for FallbackProvider of WSS RPC', async () => {
+    const config: FallbackProviderJsonConfig = {
+      chainId: 1,
+      providers: [
+        {
+          provider: 'wss://ethereum-rpc.publicnode.com',
+          priority: 1,
+          weight: 2,
+          stallTimeout: 2500,
+        }
       ],
     };
 

--- a/src/utils/__tests__/available-rpc.test.ts
+++ b/src/utils/__tests__/available-rpc.test.ts
@@ -8,7 +8,7 @@ import {
 chai.use(chaiAsPromised);
 const { expect } = chai;
 
-describe.only('available-rpc', () => {
+describe('available-rpc', () => {
   it('Should check fallback provider cascade for FallbackProvider of HTTPS RPCs', async () => {
     const config: FallbackProviderJsonConfig = {
       chainId: 1,

--- a/src/utils/available-rpc.ts
+++ b/src/utils/available-rpc.ts
@@ -1,5 +1,5 @@
 /// <reference types="../types/global" />
-import { JsonRpcProvider, Network } from 'ethers';
+import { JsonRpcProvider, Network, Provider, WebSocketProvider } from 'ethers';
 import { ProviderJson } from './fallback-provider';
 import { getUpperBoundMedian } from './median';
 import { promiseTimeout } from './promises';
@@ -65,9 +65,19 @@ const getBlockNumber = async (
   logError: LogError,
 ): Promise<Optional<number>> => {
   const network = Network.from(chainId);
-  const rpcProvider = new JsonRpcProvider(provider, network, {
-    staticNetwork: network,
-  });
+
+  // Conditionally handle what type of provider is being passed
+  let rpcProvider: Provider;
+
+  // If URL starts with wss, use WebSocketProvider
+  if(provider.startsWith('wss')) {
+    rpcProvider = new WebSocketProvider(provider, network);
+  } else {
+    rpcProvider = new JsonRpcProvider(provider, network, {
+      staticNetwork: network,
+    });
+  }
+
   try {
     const block = await promiseTimeout(
       rpcProvider.getBlock('latest'),

--- a/src/utils/available-rpc.ts
+++ b/src/utils/available-rpc.ts
@@ -1,5 +1,5 @@
 /// <reference types="../types/global" />
-import { JsonRpcProvider, Network, Provider, WebSocketProvider } from 'ethers';
+import { JsonRpcProvider, Network, type Provider, WebSocketProvider } from 'ethers';
 import { ProviderJson } from './fallback-provider';
 import { getUpperBoundMedian } from './median';
 import { promiseTimeout } from './promises';


### PR DESCRIPTION
**Problem**

Health check currently assumes provider is of type `JsonRpcProvider`, which fails with `WebSocketProvider` types. 
Engine is currently being upgraded to allow wss providers for `loadNetwork`, which exposed the issue here. 

**Solution**

If the provider URL string starts with `wss`, health check as a `WebSocketProvider` type. Similar logic is already used elsewhere in this repo. 