### PR TITLE
Fix Typo in Type Name: UnshielIdAdditionalData → UnshieldAdditionalData

### DIFF
--- a/src/models/response-types.ts
+++ b/src/models/response-types.ts
@@ -230,16 +230,16 @@ export type RailgunHistorySendERC20Amount = RailgunHistoryERC20Amount &
 export type RailgunHistorySendNFTAmount = RailgunHistoryNFTAmount &
   SendAdditionalData;
 
-type UnshieldAdditonalData = {
+type UnshieldAdditionalData = {
   unshieldFee: Optional<string>;
   hasValidPOIForActiveLists: boolean;
 };
 
 export type RailgunHistoryUnshieldERC20Amount = RailgunHistorySendERC20Amount &
-  UnshieldAdditonalData;
+  UnshieldAdditionalData;
 
 export type RailgunHistoryUnshieldNFTAmount = RailgunHistorySendNFTAmount &
-  UnshieldAdditonalData;
+  UnshieldAdditionalData;
 
 type ReceiveAdditionalData = {
   senderAddress: Optional<string>;


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the type name from UnshielIdAdditionalData to UnshieldAdditionalData in the response-types.ts file. The change ensures consistent and correct naming throughout the codebase. All references to the old type name have been updated accordingly. No functional changes were made.
