### PR TITLE
fix: export types in global type file so they are included in the bui…

### DIFF
--- a/src/models/artifact.ts
+++ b/src/models/artifact.ts
@@ -1,3 +1,5 @@
+import type { Optional } from '../types/global';
+
 export type Artifact = {
   zkey: ArrayLike<number>;
   wasm: Optional<ArrayLike<number>>;

--- a/src/models/broadcaster.ts
+++ b/src/models/broadcaster.ts
@@ -5,6 +5,7 @@ import {
   CommitmentCiphertextV3,
   PreTransactionPOIsPerTxidLeafPerList,
 } from './response-types';
+import type { MapType, Optional } from '../types/global';
 
 export const MIN_BROADCASTER_RELIABILITY_SCORE = 0.75;
 

--- a/src/models/function-types.ts
+++ b/src/models/function-types.ts
@@ -1,4 +1,5 @@
 import { Chain } from './response-types';
+import type { Optional } from '../types/global';
 
 export type RailgunBalanceRefreshTrigger = (
   chain: Chain,

--- a/src/models/network-config.ts
+++ b/src/models/network-config.ts
@@ -1,4 +1,5 @@
 import { Chain, ChainType, EVMGasType } from './response-types';
+import type { Optional } from '../types/global';
 
 /**
  * DO NOT CHANGE THESE ENUM STRINGS.

--- a/src/models/proof-of-innocence.ts
+++ b/src/models/proof-of-innocence.ts
@@ -1,6 +1,7 @@
 import { TXIDVersion } from './engine';
 import { NetworkName } from './network-config';
 import { PreTransactionPOIsPerTxidLeafPerList } from './response-types';
+import type { Optional } from '../types/global';
 
 // TODO: Migrate to using Chain object directly when PPOI API update is permissioned
 export type ChainParams = {

--- a/src/models/response-types.ts
+++ b/src/models/response-types.ts
@@ -1,9 +1,9 @@
-/// <reference types="../types/global" />
 import { ContractTransaction } from 'ethers';
 import { MerkletreeScanStatus } from './merkletree-scan';
 import { FeesSerialized } from './network-config';
 import { TXIDVersion } from './engine';
 import { RailgunWalletBalanceBucket } from './balance';
+import type { Optional } from '../types/global';
 
 export type RailgunAPICiphertext = {
   iv: string;

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,2 +1,0 @@
-declare type Optional<T> = T | undefined;
-declare type MapType<T> = Partial<Record<string, T>>;

--- a/src/types/global.ts
+++ b/src/types/global.ts
@@ -1,0 +1,2 @@
+export type Optional<T> = T | undefined;
+export type MapType<T> = Partial<Record<string, T>>;

--- a/src/utils/__tests__/promises.test.ts
+++ b/src/utils/__tests__/promises.test.ts
@@ -1,4 +1,3 @@
-/// <reference types="../../types/global" />
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import { delay, promiseTimeout, poll } from '../promises';

--- a/src/utils/available-rpc.ts
+++ b/src/utils/available-rpc.ts
@@ -1,8 +1,13 @@
-/// <reference types="../types/global" />
-import { JsonRpcProvider, Network, type Provider, WebSocketProvider } from 'ethers';
+import {
+  JsonRpcProvider,
+  Network,
+  type Provider,
+  WebSocketProvider,
+} from 'ethers';
 import { ProviderJson } from './fallback-provider';
 import { getUpperBoundMedian } from './median';
 import { promiseTimeout } from './promises';
+import type { Optional } from '../types/global';
 
 type LogError = (err: string) => void;
 
@@ -70,7 +75,7 @@ const getBlockNumber = async (
   let rpcProvider: Provider;
 
   // If URL starts with wss, use WebSocketProvider
-  if(provider.startsWith('wss')) {
+  if (provider.startsWith('wss')) {
     rpcProvider = new WebSocketProvider(provider, network);
   } else {
     rpcProvider = new JsonRpcProvider(provider, network, {

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,5 +1,6 @@
 import { Network, NETWORK_CONFIG, NetworkName } from '../models/network-config';
 import { Chain } from '../models/response-types';
+import type { Optional } from '../types/global';
 
 export const networkForChain = (chain: Chain): Optional<Network> => {
   return Object.values(NETWORK_CONFIG).find(

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -1,3 +1,5 @@
+import type { Optional } from '../types/global';
+
 export const delay = (delayInMS: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, delayInMS));
 };

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -1,3 +1,5 @@
+import type { Optional } from '../types/global';
+
 export const isDefined = <T>(a: T | undefined | null): a is T => {
   return typeof a !== 'undefined' && a !== null;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
     "strict": true,
-    "types": ["node", "mocha"],
-    "typeRoots": ["./node_modules/@types", "./src/types"]
+    "types": ["node", "mocha"]
   },
   "ts-node": { "files": true },
   "include": ["./src/**/*.ts"],


### PR DESCRIPTION
**Problem**

Global types are currently exported using "declare", and imported in specific files using `/// <reference`, which prevents the global types from being included in the `/dist` build folder as `/dist/types`. 

**Solution**

Export types from a `.ts` file and import where needed. `/dist/types` then exists properly. 