### PR TITLE
fix: rename BroadcasterRawParamsTransactEIP7702 to BroadcasterRawPara…

### DIFF
--- a/src/models/broadcaster.ts
+++ b/src/models/broadcaster.ts
@@ -64,7 +64,7 @@ export type BroadcasterRawParamsTransactCommon = BroadcasterTransactRequestRaw &
   minGasPrice: string;
 };
 
-export type BroadcasterRawParamsTransactEIP7702 = BroadcasterRawParamsShared & {
+export type BroadcasterRawParamsTransactERC7702 = BroadcasterRawParamsShared & {
   transactType: BroadcasterTransactRequestType.TX7702;
   // Explicit ERC-1559 fee fields. These are REQUIRED for ERC-7702 (type 4).
   maxFeePerGas: string;
@@ -74,7 +74,7 @@ export type BroadcasterRawParamsTransactEIP7702 = BroadcasterRawParamsShared & {
 
 export type BroadcasterRawParamsTransact =
   | BroadcasterRawParamsTransactCommon
-  | BroadcasterRawParamsTransactEIP7702;
+  | BroadcasterRawParamsTransactERC7702;
 
 export type BroadcasterRawParamsPreAuthorize = BroadcasterRawParamsShared & {
   gasLimit: string;


### PR DESCRIPTION
This pull request makes a minor update to the type definitions in `src/models/broadcaster.ts` to improve naming consistency. Specifically, it renames the type for ERC-7702 transactions from `BroadcasterRawParamsTransactEIP7702` to `BroadcasterRawParamsTransactERC7702`, and updates its usage accordingly.

- Type renaming for clarity:
  * Renamed `BroadcasterRawParamsTransactEIP7702` to `BroadcasterRawParamsTransactERC7702` and updated all references in the union type for `BroadcasterRawParamsTransact`. [[1]](diffhunk://#diff-565268310a489ae18a4a7d63ad01dc75bc4a0007d3d29e768e511c220f667287L67-R67) [[2]](diffhunk://#diff-565268310a489ae18a4a7d63ad01dc75bc4a0007d3d29e768e511c220f667287L77-R77)