### PR TITLE
Update release steps to provide NPM token via OIDC

### DIFF
--- a/.github/workflows/publish-npmjs.yml
+++ b/.github/workflows/publish-npmjs.yml
@@ -4,6 +4,11 @@ on:
     # Sequence of patterns matched against refs/heads
     branches:    
       - release
+
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,5 +22,3 @@ jobs:
       - run: npm install
       - run: npm ci
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Changes:
- Updates publish-npmjs.yml to use OIDC publishing